### PR TITLE
Track defenders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/api/index.js
+++ b/api/index.js
@@ -1,9 +1,15 @@
 const express = require('express');
 const scenecontrol = require('./scenecontrol.js');
+const defenders = require('./routers/defenders.js');
 const app = express();
 var cors = require('cors');
 
+// Express middleware setup
 app.use(cors());
+
+// Express local constants initialization
+app.locals.currentAttackId = 0;
+app.locals.defendersCount = {};
 
 scenecontrol.setCurrentPage(0);
 
@@ -55,13 +61,17 @@ app.get('/api/statusjson', (req, res) => {
     res.json({
         thePage: pageInt ,
         currentEpochStamp: timeInt ,
-        currentSeconds: s
+        currentSeconds: s,
+        currentAttackId: app.locals.currentAttackId
     }
     )
 })
 
-
+/**
+ * @todo This should be a PATCH as it's updating an existing resource 
+ */
 app.get('/api/pageset/:num', (req, res) => {
+    app.locals.currentAttackId++;
     var pageInt = parseInt(req.params.num);
     console.log(scenecontrol.currentPage());
     scenecontrol.setCurrentPage(pageInt);
@@ -78,6 +88,8 @@ function secondsSolver(someNum){
    return a;
 }
 
+// Routes
+app.use("/api/defenders", defenders.defendersRouterCreator(app));
 
 /*
 app.get('/api/pageset/:num', (req, res) => {

--- a/api/routers/defenders.js
+++ b/api/routers/defenders.js
@@ -1,0 +1,53 @@
+const express = require('express');
+
+/**
+ * Function to create a router for the "/defenders" endpoint that handles tracking and
+ * displaying the number of defenders for each attack.
+ * @param {Express} app The express application, used to retrieve and update local constants.
+ * @returns {Router} A router to be set on the "/defenders" endpoint.
+ */
+const defendersRouterCreator = (app) => {
+  const router = express.Router();
+
+  // Custom middleware to 404 if the request attack id is higher than the app's currentAttackId
+  const attackNotFoundMiddleware = (req, res, next) => {
+    const attackId = req.params.attackId;
+    if (attackId && attackId > app.locals.currentAttackId) {
+      return res.status(404).end();
+    }
+    next();
+  }
+
+  // PATCH method allowing defenders to register
+  router.patch('/:attackId', attackNotFoundMiddleware, (req, res, _next) => {
+    const attackId = req.params.attackId;
+    const defendersCount = app.locals.defendersCount;
+
+    // If this is the first received defender, initialize count
+    if (!defendersCount[attackId]) {
+      defendersCount[attackId] = 0;
+    }
+    defendersCount[attackId] += 1;
+
+    app.locals.defendersCount = defendersCount;
+
+    res.status(200).end();
+  });
+
+  // GET method for the defenders count of all attacks
+  router.get('/', (_req, res, _next) => {
+    res.json(app.locals.defendersCount);
+  });
+
+  // GET method for the defenders count of one attack
+  router.get('/:attackId', attackNotFoundMiddleware, (req, res, next) => {
+    const attackId = req.params.attackId;
+    const numDefenders = app.locals.defendersCount[attackId];
+
+    res.send(`The number of defenders for attack ${attackId} is ${numDefenders ? numDefenders : '0'}`); 
+  });
+
+  return router;
+}
+
+module.exports.defendersRouterCreator = defendersRouterCreator;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "express-demo",
+  "name": "ScryMirror",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "express-demo",
+      "name": "ScryMirror",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "main": "api/index.js",
   "scripts": {
+    "start": "node api/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "GloopQueen",


### PR DESCRIPTION
- Updated the `package-lock.json` as a side effect of installing (pulled in new project name).
- Added a `.gitignore` file to ignore installed dependencies in `node_modules`.
- Added a new script to `package.json` to allow for easier start of server (only have to enter `npm start` into CLI).
- Added a `currentAttackId` and `defendersCount` to the app local variables.
- Incremented `currentAttackId` when the page is set on the `/api/pageset/:num` endpoint.
- Added `currentAttackId` to the JSON object returned by `/api/statusjson`
- Added a new router for managing `defenders` endpoints and set it on `/api/defenders`.
  - PATCH `/api/defenders/:attackId` will increment the value on `defendersCount` using the `attackId` as the key, initializing it if it's undefined.
  - GET `/api/defenders` will return the whole `defendersCount` object using JSON.
  - GET `/api/defenders/:attackId` will return the count for the `attackId` parameter.
  - GET/PATCH on `/api/defenders/:attackId` will return a 404 if the `attackId` parameter is higher than the `currentAttackId` using middleware approach to share logic between endpoints.